### PR TITLE
fixes date typo in hack-week description.

### DIFF
--- a/hack weeks.md
+++ b/hack weeks.md
@@ -1,16 +1,16 @@
 # Hack Weeks
 
-At Next Big Sound, hacking and inventing have been a tradition since the very beginning. In fact, our first "hack" was the original MySpace parser: A simple web page that made an XHR request to a web-server. That web-server fetched the contents from an XML endpoint, parsed the contents, and returned the value back to the web-client. The web-client made requests every 10 seconds; we left it running overnight and in the morning we saw that Akon had generated > 500,000 plays! 
+At Next Big Sound, hacking and inventing have been a tradition since the very beginning. In fact, our first "hack" was the original MySpace parser: A simple web page that made an XHR request to a web-server. That web-server fetched the contents from an XML endpoint, parsed the contents, and returned the value back to the web-client. The web-client made requests every 10 seconds; we left it running overnight and in the morning we saw that Akon had generated > 500,000 plays!
 
-We're focused every day on making data useful for our customers. More often than not, the most creative ideas are what drives this forward. To this end, Next Big Sound has internal hack weeks to explore and experiment, to disrupt and provide healthy chaos, and to bring to life ideas that once only lived on paper or in your head. 
+We're focused every day on making data useful for our customers. More often than not, the most creative ideas are what drives this forward. To this end, Next Big Sound has internal hack weeks to explore and experiment, to disrupt and provide healthy chaos, and to bring to life ideas that once only lived on paper or in your head.
 
-Starting in November 2014, we'll have company-wide Hack Weeks every 3 months. (We previously had 2-day company-wide Hack Days every 2 months, and engineers had individual Hack Weeks about once a quarter). 
+Starting in November 2014, we'll have company-wide Hack Weeks every 3 months. (We previously had 2-day company-wide Hack Days every 2 months, and engineers had individual Hack Weeks about once a quarter).
 
-Here’s how Hack Weeks run: 
+Here’s how Hack Weeks run:
 - During the weeks leading up to the Hack Week, folks are encouraged to add ideas and projects to the [NBS: Hack Week board](https://trello.com/b/6Wu6JciJ/nbs-hack-week)
 - On the first day of Hack Week (a Wednesday), people will discuss ideas and select the ones they want to work on
 - Hacking happens for the next 7 days (and, entirely optionally, can include the weekend)
 - On the following Tuesday, folks present their hacks to the entire company during Demo Day
 
 # Next Hack Week Date
-- TBD in Q1, 2014
+- TBD in Q1, 2015


### PR DESCRIPTION
also scrubs unnecessary whitespace.  (2014 -> 2015)